### PR TITLE
use sydney time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,3 +3,4 @@ FROM amazoncorretto:8
 COPY newrelic-agent-5.9.0/newrelic.jar /newrelic/newrelic.jar
 COPY newrelic-agent-5.9.0/newrelic.yml /newrelic/newrelic.yaml
 
+RUN ln -sf /usr/share/zoneinfo/Australia/Sydney /etc/localtime


### PR DESCRIPTION
I just realised today app from our bedrock aren't logging in Sydney time. 

Tested with
```
#build locally
docker build . -t 053457794187.dkr.ecr.ap-southeast-2.amazonaws.com/fsa-streamotion/streamotion-java:sydney

# should show current Sydney time (as opposed to UTC with current tag: `corretto-0.0.3`)
docker run 053457794187.dkr.ecr.ap-southeast-2.amazonaws.com/fsa-streamotion/streamotion-java:sydney date
```